### PR TITLE
Use EUI-48 format to show MAC addresses

### DIFF
--- a/src/capwap_dp.erl
+++ b/src/capwap_dp.erl
@@ -148,11 +148,11 @@ handle_info({packet_in, tap, VlanId, Packet}, State) ->
 	    ok;
 
 	<<_:7, 1:1, _/binary>> ->
-	    lager:warning("need to handle multicast on VLAN ~w to ~s", [VlanId, flower_tools:format_mac(MAC)]),
+	    lager:warning("need to handle multicast on VLAN ~w to ~s", [VlanId, ieee80211_station:format_eui(MAC)]),
 	    ok;
 
 	_ ->
-	    lager:warning("packet for invalid STA ~s on VLAN ~w", [flower_tools:format_mac(MAC), VlanId]),
+	    lager:warning("packet for invalid STA ~s on VLAN ~w", [ieee80211_station:format_eui(MAC), VlanId]),
 	    ok
     end,
     {noreply, State};

--- a/src/capwap_http_api_handler.erl
+++ b/src/capwap_http_api_handler.erl
@@ -231,10 +231,10 @@ fmt_dp_wtp_stats(true, {RcvdPkts, SendPkts, RcvdBytes, SendBytes,
 fmt_dp_wtp_stats(_, _, Acc) -> Acc.
 
 fmt_dp_wtp_stas(false, {MAC, _RadioId, _BSS, _Stats}) ->
-    [{mac, ieee80211_station:format_mac(MAC)}];
+    [{mac, ieee80211_station:format_eui(MAC)}];
 fmt_dp_wtp_stas(true, {MAC, _RadioId, _BSS, Stats}) ->
     {RcvdPkts, SendPkts, RcvdBytes, SendBytes} = Stats,
-    [{mac, ieee80211_station:format_mac(MAC)},
+    [{mac, ieee80211_station:format_eui(MAC)},
      {input, [{bytes, RcvdBytes},
               {packets, RcvdPkts}]},
      {output, [{bytes, SendBytes},
@@ -291,7 +291,7 @@ fmt_wtp_board_data_sub_element({3, Value}) ->
     {board_revision, Value};
 fmt_wtp_board_data_sub_element({4, Value})
   when is_binary(Value), size(Value) == 6 ->
-    {base_mac, fmt_mac(Value)};
+    {base_mac, ieee80211_station:format_eui(Value)};
 fmt_wtp_board_data_sub_element({4, Value}) ->
     {base_mac, Value};
 fmt_wtp_board_data_sub_element({Id, Value}) ->
@@ -300,10 +300,6 @@ fmt_wtp_board_data_sub_element({Id, Value}) ->
 vendor_id_str(18681) -> <<"Travelping GmbH">>;
 vendor_id_str(31496) -> <<"NetModule AG">>;
 vendor_id_str(Id) -> Id.
-
-fmt_mac(<<A:8, B:8, C:8, D:8, E:8, F:8>>) ->
-    bin_fmt("~2.16.0b:~2.16.0b:~2.16.0b:~2.16.0b:~2.16.0b:~2.16.0b",
-            [A, B, C, D, E, F]).
 
 fmt_endpoint({IP, Port}) ->
     [{ip, fmt_ip(IP)}, {port, Port}].
@@ -345,4 +341,4 @@ bin_fmt(FmtStr, Args) ->
     erlang:list_to_binary(io_lib:format(FmtStr, Args)).
 
 fmt_station_mac(Station) ->
-    bin_fmt("~s", [ieee80211_station:format_mac(Station)]).
+    bin_fmt("~s", [ieee80211_station:format_eui(Station)]).


### PR DESCRIPTION
Across `capwap-ac` we use a set of different, allthough correct,
variants to format the MAC address of entities:

* ieee80211_station:format_mac/1 uses lowercase hex-values, separated by
  colons.
* flower_tools:format_mac/1 uses uppercase hex-values, separated by
  colons.

An encoding to use for MAC addresses is EUI-48, as described in
http://standards.ieee.org/develop/regauth/tut/eui.pdf. The octets are
given uppercase and are separated via hyphens.

This commit uses the EUI-48 format to render MAC addresses in various
places, either for log messages or as part of AAA-sessions.