### PR TITLE
Readd support to report to InfluxDB

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -5,6 +5,7 @@
     {setup,         "2.0.2"},
     {lager,         "3.6.6"},
     {exometer_core, "1.5.2"},
+    {exometer_influxdb, "0.6.0"},
     {erlando,       {git, "https://github.com/travelping/erlando.git", {tag, "1.0.2"}}},
     {dtlsex,        {git, "git://github.com/RoadRunnr/dtlsex.git", {branch, "master"}}},
     {regine,        {git, "git://github.com/travelping/regine.git", {branch, "master"}}},


### PR DESCRIPTION
Somewhere in the process of going from capwap-1.7.0 to 2.0.0 the
exometer-influxdb reporter was lost. Since InfluxDB is still in use in
some production sites, not having the InfluxDB client in place makes
upgrading to capwap-2.x a show stopper.

This commit (re)adds support for InfluxDB.