### PR TITLE
FIx failed to boot recon

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -71,7 +71,6 @@
 	  exometer_influxdb,
 	  sasl,
 	  runtime_tools,
-	  recon,
 	  observer]},
 	{exclude_apps, [wx]},
 


### PR DESCRIPTION
Fix for `./rebar3 shell`:
```sh
===> Failed to boot recon for reason {"no such file or directory",
                                                 "recon.app"}
```