### PR TITLE
Update alpine to 3.13 for Dockerfile

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        otp: [21.3.8.18, 22.0.7, 22.1.8, 22.2.8, 22.3.4.14, 23.0.4, 23.1.5.0, 23.2.1.0]
+        otp: [21.3.8.18, 22.0.7, 22.1.8, 22.2.8, 22.3.4.14, 23.0.4, 23.1.5.0, 23.2.7.0]
     container:
       image: erlang:${{ matrix.otp }}-alpine
     steps:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 # -- build-environment --
 # see https://docs.docker.com/engine/userguide/eng-image/multistage-build/
 
-FROM erlang:22.2.7-alpine AS build-env
+FROM erlang:23.2.7.0-alpine AS build-env
 
 ARG     BUILD_PROFILE=prod
 WORKDIR /build
@@ -31,7 +31,7 @@ RUN     export BUILD_PROFILE=$(echo $BUILD_PROFILE | sed 's/+/,/g') && \
 
 # -- runtime image --
 
-FROM    alpine:3.11
+FROM    alpine:3.13
 
 ARG     BUILD_PROFILE=prod
 WORKDIR /

--- a/rebar.config
+++ b/rebar.config
@@ -35,8 +35,7 @@
 		     ]},
 	      {deps, [
 		      {recon, "2.5.1"},
-		      {observer_cli, "1.5.4"},
-		      {entop, {git, "https://github.com/mazenharake/entop.git", {tag, "0.4.2"}}}
+		      {observer_cli, "1.5.4"}
 		     ]}
 	     ]},
 	    {native,


### PR DESCRIPTION
The https://github.com/erlang/docker-erlang-otp/blob/master/23/alpine/Dockerfile#L1
has base image what based upon alpine:3.13.
**NOTES:**
>The alpine:3.13 is based on musl 1.2.X. https://musl.libc.org/releases.html:
musl-1.2.1.tar.gz (sig) - August 4, 2020
This release features the new "mallocng" malloc implementation, replacing musl's
original dlmalloc-like allocator that suffered from fundamental design problems.
Its major user-facing new properties are the ability to return freed memory
on a much finer granularity and avoidance of many catastrophic fragmentation patterns.
In addition it provides strong hardening against memory usage errors by the caller,
including detection of overflows, double-free, and use-after-free,
and does not admit corruption of allocator state via these errors.