### PR TITLE
Upgrade to Erlang-22.3.4.16

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        otp: [21.3.8.18, 22.0.7, 22.1.8, 22.2.8, 22.3.4.14, 23.0.4, 23.1.5.0, 23.2.1.0]
+        otp: [21.3.8.18, 22.0.7, 22.1.8, 22.2.8, 22.3.4.16, 23.0.4, 23.1.5.0, 23.2.1.0]
     container:
       image: erlang:${{ matrix.otp }}-alpine
     steps:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 # -- build-environment --
 # see https://docs.docker.com/engine/userguide/eng-image/multistage-build/
 
-FROM erlang:22.2.7-alpine AS build-env
+FROM erlang:22.3.4.16-alpine AS build-env
 
 ARG     BUILD_PROFILE=prod
 WORKDIR /build
@@ -31,7 +31,7 @@ RUN     export BUILD_PROFILE=$(echo $BUILD_PROFILE | sed 's/+/,/g') && \
 
 # -- runtime image --
 
-FROM    alpine:3.11
+FROM    alpine:3.13
 
 ARG     BUILD_PROFILE=prod
 WORKDIR /


### PR DESCRIPTION
This commit bumps the Erlang version to 22.3.4.16 As a side effect, the
new base image is alpine:3.13.

The main reason to bump the used Erlang version is mainly to get to
alpine:3.13. It contains an overhaul in their libc-equivalent "musl"
which adresses memory allocation (see [1]):

    musl-1.2.1.tar.gz (sig) - August 4, 2020
    This release features the new "mallocng" malloc implementation,
    replacing musl's original dlmalloc-like allocator that suffered
    from fundamental design problems. Its major user-facing new
    properties are the ability to return freed memory on a much finer
    granularity and avoidance of many catastrophic fragmentation
    patterns. In addition it provides strong hardening against memory
    usage errors by the caller, including detection of overflows,
    double-free, and use-after-free, and does not admit corruption of
    allocator state via these errors.

[1]: https://musl.libc.org/releases.html
[2]: https://inbox.vuxu.org/musl/20200205200022.GD1663@brightrain.aerifal.cx/T/