### PR TITLE
Crash upon /api/v1/dp/wtp-list

### DIFF
--- a/src/capwap_dp.erl
+++ b/src/capwap_dp.erl
@@ -32,7 +32,7 @@
          terminate/2, code_change/3]).
 
 %% dev API
--export([run/1]).
+-export([run/1, get_node/0]).
 
 -include_lib("kernel/include/logger.hrl").
 -include("include/capwap_packet.hrl").

--- a/test/capwap_http_api_SUITE.erl
+++ b/test/capwap_http_api_SUITE.erl
@@ -21,7 +21,9 @@ all() ->
      http_api_prometheus_metrics_sub_req,
      http_api_metrics_req,
      http_api_metrics_sub_req,
-     http_api_bad_command
+     http_api_bad_command,
+     http_api_dp_wtp_list_error,
+     http_api_dp_status_error
     ].
 
 init_per_suite(Config0) ->
@@ -187,6 +189,26 @@ http_api_bad_command(_Config) ->
     {ok, {_, _, Body0}} = httpc:request(get, {URL0, []},
 				       [], [{body_format, binary}]),
     ?assertEqual(<<>>, Body0),
+    ok.
+
+http_api_dp_wtp_list_error() ->
+    [{doc, "Check /api/v1/dp/wtp-list API with capwap-dp node down"}].
+http_api_dp_wtp_list_error(_Config) ->
+    URL = get_test_url("/api/v1/dp/wtp-list"),
+    {ok, {_, _, Body}} = httpc:request(get, {URL, []},
+				       [], [{body_format, binary}]),
+    Res = jsx:decode(Body, [return_maps]),
+    ?assertEqual(<<"error">>, maps:get(<<"type">>, Res)),
+    ok.
+
+http_api_dp_status_error() ->
+    [{doc, "Check /api/v1/dp/status API with capwap-dp node down"}].
+http_api_dp_status_error(_Config) ->
+    URL = get_test_url("/api/v1/dp/stats"),
+    {ok, {_, _, Body}} = httpc:request(get, {URL, []},
+				       [], [{body_format, binary}]),
+    Res = jsx:decode(Body, [return_maps]),
+    ?assertEqual(<<"error">>, maps:get(<<"type">>, Res)),
     ok.
 
 %%%===================================================================


### PR DESCRIPTION
Handle crash when `capwap` have issue with `capwap-dp` during a call of REST APIs `/api/v1/dp/stats` and `/api/v1/dp/wtp-list`.
Example:
```sh
$ curl -v "http://localhost:8080/api/v1/dp/wtp-list"
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET /api/v1/dp/wtp-list HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.58.0
> Accept: */*
> 
< HTTP/1.1 500 Internal Server Error
< content-length: 107
< content-type: application/json
< date: Thu, 18 Mar 2021 19:29:54 GMT
< server: Cowboy
< vary: accept
< 
* Connection #0 to host localhost left intact
{"dp_node":"capwap-dp@pc","message":"Something is wrong with 'capwap-dp'","ping_status":"pang","type":"error"}
```
```sh
$ curl -v http://localhost:8080/api/v1/dp/stats
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET /api/v1/dp/stats HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.58.0
> Accept: */*
> 
< HTTP/1.1 500 Internal Server Error
< content-length: 107
< content-type: application/json
< date: Thu, 18 Mar 2021 19:29:38 GMT
< server: Cowboy
< vary: accept
< 
* Connection #0 to host localhost left intact
{"dp_node":"capwap-dp@pc","message":"Something is wrong with 'capwap-dp'","ping_status":"pang","type":"error"}
```