### PR TITLE
Update alpine to 3.14

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,7 +31,7 @@ RUN     export BUILD_PROFILE=$(echo $BUILD_PROFILE | sed 's/+/,/g') && \
 
 # -- runtime image --
 
-FROM    alpine:3.13
+FROM    alpine:3.14
 
 ARG     BUILD_PROFILE=prod
 WORKDIR /


### PR DESCRIPTION
Currently all TP images is use `alpine:3.14`. Related to https://github.com/travelping/capwap-dp/pull/16.